### PR TITLE
Updated addresses so it works for the newly released unprotected executable

### DIFF
--- a/src/commands/event.h
+++ b/src/commands/event.h
@@ -38,7 +38,7 @@ class EventCommand : public ICommand
             return false;
         }
 
-        hk::func_call<void>(0x14328A590, arguments.c_str(), nullptr);
+        hk::func_call<void>(0x1400719D0, arguments.c_str(), nullptr);
         return true;
     }
 

--- a/src/commands/spawn.h
+++ b/src/commands/spawn.h
@@ -32,7 +32,7 @@ class SpawnCommand : public ICommand
     virtual void Initialize() override
     {
         static hk::inject_call<PropertyFileResult *, void *, PropertyFileResult *, uint32_t> add_event_hook(
-            0x1447EC034);
+            0x140EBFBD7);
         add_event_hook.inject([](void *file, PropertyFileResult *buf, uint32_t hash) {
             PropertyFileResult model;
 

--- a/src/commands/world.h
+++ b/src/commands/world.h
@@ -17,14 +17,14 @@ class WorldCommand : public ICommand
 
     virtual bool Handler(const std::string& arguments) override
     {
-        static auto WorldTime = *(void**)0x142F17250;
+        static auto WorldTime = *(void**)0x142F17250; //CDayCycle
 
         // time
         if (arguments.find("time ") != std::string::npos) {
             float time = 0.0f;
             if (sscanf_s(arguments.c_str(), "time %f", &time) == 1) {
                 time = std::clamp(time, -24.0f, 24.0f);
-                hk::func_call<void>(0x1437E37B0, WorldTime, time);
+                hk::func_call<void>(0x14052CD20, WorldTime, time);
                 return true;
             }
         }

--- a/src/game/spawn_system.h
+++ b/src/game/spawn_system.h
@@ -29,7 +29,7 @@ class CSpawnSystem
 
         auto request = new SpawnReq{callback, userdata};
         hk::func_call<void>(
-            0x1447C1140, this, model_name.c_str(), transform, 0x2013C,
+            0x140E97DA0, this, model_name.c_str(), transform, 0x2013C,
             (success_t)[](const spawned_objects& objects, void* userdata) {
                 auto spawn_req = (SpawnReq*)userdata;
                 spawn_req->callback(objects, spawn_req->userdata);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,30 +66,30 @@ HRESULT          D3D11CreateDevice(IDXGIAdapter *pAdapter, D3D_DRIVER_TYPE Drive
             hk::put<bool>(0x142F3407A, true);
 
             // IsIntroSequenceComplete always returns true
-            hk::put<uint32_t>(0x144883EE0, 0x90C301B0);
+            hk::put<uint32_t>(0x140F46280, 0x90C301B0);
 
             // IsIntroMovieComplete always returns true
-            hk::put<uint32_t>(0x144883F60, 0x90C301B0);
+            hk::put<uint32_t>(0x140F46300, 0x90C301B0);
         }
 
         HWND hwnd    = *(HWND *)0x142E22A18;
         WndProc_orig = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)WndProc);
 
         // focus lost
-        static hk::inject_call<void, HWND, bool> lose_focus(0x143218620);
+        static hk::inject_call<void, HWND, bool> lose_focus(0x14000B291);
         lose_focus.inject([](HWND hwnd, bool a2) {
             lose_focus.call(hwnd, a2);
             Input::Get()->FocusChanged(true);
         });
 
         // focus gained
-        static hk::inject_call<void, HWND> gain_focus(0x143218611);
+        static hk::inject_call<void, HWND> gain_focus(0x14000B284);
         gain_focus.inject([](HWND hwnd) {
             gain_focus.call();
             Input::Get()->FocusChanged(false);
         });
 
-        static hk::inject_call<int64_t, jc::HDevice_t *> flip(0x1432E0071);
+        static hk::inject_call<int64_t, jc::HDevice_t *> flip(0x1400B8A22);
         flip.inject([](jc::HDevice_t *device) {
             Graphics::Get()->BeginDraw(device);
 


### PR DESCRIPTION
As of 17 December 2025 the game received an update which replaced the Denuvo protected executable with an unprotected executable which broke all of the hooks (more precisely the addresses that point to a function are now invalid) in this code base.

I simply just updated every address so it now works with the latest version of the game on steam.